### PR TITLE
Add meta tags required by bootstrap

### DIFF
--- a/templates/submit_form.html
+++ b/templates/submit_form.html
@@ -2,6 +2,8 @@
 <!doctype html>
 <html>
     <head>
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
         <link type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
         <style>
             body {


### PR DESCRIPTION
Layout was improperly scaled on mobile devices.